### PR TITLE
Updated query to pull eBay orders

### DIFF
--- a/routes/GetEbayOrder.cs
+++ b/routes/GetEbayOrder.cs
@@ -19,18 +19,18 @@ namespace magestack.routes
 
         [FunctionName("GetEbayOrder")]
         public async Task<IActionResult> Run(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "ebay/orders/{email}")] HttpRequest req,
-            string email,
+            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "ebay/orders/{orderId}")] HttpRequest req,
+            string orderId,
             ILogger log)
         {
             IActionResult res;
-            log.LogInformation($"Looking for an eBay order with email: {email}");
+            log.LogInformation($"Looking for an eBay order with eBay order ID: {orderId}");
 
             using (MySqlConnection cxn = new MySqlConnection(_cs))
             using (MySqlCommand cmd = cxn.CreateCommand())
             {
                 cxn.Open();
-                cmd.CommandText = @$"SELECT sales_order.entity_id AS 'id',
+                cmd.CommandText = $@"SELECT sales_order.entity_id AS 'id',
                     state,
                     `status`,
                     shipping_description AS 'shipping',
@@ -43,8 +43,10 @@ namespace magestack.routes
                     increment_id AS 'order_number',
                     payment.method
                 FROM sales_order
+                INNER JOIN m2epro_order ON magento_order_id = sales_order.entity_id
+                INNER JOIN m2epro_ebay_order ON order_id = m2epro_order.id
                 JOIN sales_order_payment AS payment ON payment.parent_id = sales_order.entity_id
-                WHERE customer_email = '{email}';";
+                WHERE ebay_order_id = '{orderId}';";
 
                 using MySqlDataReader reader = cmd.ExecuteReader();
                 if (!reader.HasRows)


### PR DESCRIPTION
Updated eBay query to use eBay order number and return a unique order. Filtering by email would return more than one order or would fail to find recent orders due to how M2E creates eBay orders.